### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2010 James Halliday (mail@substack.net)
+Copyright 2014 James Halliday (mail@substack.net)
 
 This project is free software released under the MIT license:
 http://www.opensource.org/licenses/mit-license.php 


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info