### PR TITLE
Upgraded weak dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jsonify" : "~0.0.0"
   },
   "optionalDependencies": {
-    "weak": "~0.3.0"
+    "weak": "~0.4.1"
   },
   "devDependencies" : {
     "tape" : "~2.3.2"


### PR DESCRIPTION
Updated dependency to address iojs 2 and node 0.12 issue.

Tests pass.

https://github.com/substack/dnode/issues/161