### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "engine" : {
     "node" : ">=0.6.0"
   },
+  "license" : "MIT",
   "author" : {
     "name" : "James Halliday",
     "email" : "mail@substack.net",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/