### PR TITLE
Add reconnect example

### DIFF
--- a/example/reconnect/.gitignore
+++ b/example/reconnect/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/example/reconnect/connect.js
+++ b/example/reconnect/connect.js
@@ -1,0 +1,29 @@
+var dnode = require('../../');
+var net = require('net');
+var inject = require('reconnect-core');
+
+var reconnect = inject(function() {
+  return net.connect.apply(null, arguments);
+  // End this every second.
+});
+
+reconnect({}, function(net) {
+    net.on('error', function(err) {
+      console.log(err);
+    });
+
+    // Initialize dnode.
+    var d = dnode();
+    net.pipe(d).pipe(net);
+
+    d.on('remote', function (remote) {
+        console.log("Connected to dnode server");
+        remote.transform('beep', function (s) {
+            console.log('beep => ' + s);
+        });
+    });
+
+    setTimeout(function(){console.log('closing dnode'); d.end();}, 2000);
+})
+.on('reconnect', function(n) { console.log("\n\nreconnecting...\n"); })
+.connect(5004);

--- a/example/reconnect/listen.js
+++ b/example/reconnect/listen.js
@@ -1,0 +1,16 @@
+var dnode = require('../../');
+var net = require('net');
+
+var server = net.createServer(function (c) {
+    c.on('error', function(err) {
+      console.log(err);
+    });
+    var d = dnode({
+        transform : function (s, cb) {
+            cb(s.replace(/[aeiou]{2,}/, 'oo').toUpperCase());
+        }
+    });
+    c.pipe(d).pipe(c);
+});
+
+server.listen(5004);

--- a/example/reconnect/package.json
+++ b/example/reconnect/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "reconnect",
+  "version": "1.0.0",
+  "description": "dnode example using reconnect",
+  "main": "connect.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "reconnect-core": "^1.0.1"
+  }
+}


### PR DESCRIPTION
Most production installs will need reconnection capability. This PR adds
an example demonstrating how to use reconnect-core with dnode.

Closes #154