### PR TITLE
converting incoming data to string after concatenating the buffers

### DIFF
--- a/lib/dnode.js
+++ b/lib/dnode.js
@@ -93,10 +93,7 @@ dnode.prototype.write = function (buf) {
             if (buf[i] === 0x0a) {
                 self._bufs.push(buf.slice(j, i));
                 
-                var line = '';
-                for (var k = 0; k < self._bufs.length; k++) {
-                    line += String(self._bufs[k]);
-                }
+                var line = String(Buffer.concat(self._bufs));
                 
                 try { row = json.parse(line) }
                 catch (err) { return self.end() }


### PR DESCRIPTION
dnode.write() collects incoming data in buffers. It then converts each buffer to a string and concatenates these strings to get the message.

A problem occurs if there is an multi-byte character (e.g. 'Ö') splitted between two buffers. In this case the first part of the character is converted to a string (resulting in the wrong character) and concatenated with the second part converted to a string (other wrong character). The original character is lost and the message is damaged.

My fix solves this by concatenating the buffers first and then converting them to a string.