### PR TITLE
Updated link

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -281,7 +281,7 @@ between scripts written in different languages.
 * [dnode-perl](http://github.com/substack/dnode-perl)
 * [dnode-ruby](http://github.com/substack/dnode-ruby)
 * [dnode-php](https://github.com/bergie/dnode-php)
-* [dnode-php-sync-client](https://github.com/erasys/dnode-php-sync-client)
+* [dnode-php-sync-client](https://github.com/uuf6429/dnode-php-sync-client)
 * [dnode-java](https://github.com/aslakhellesoy/dnode-java)
 
 # shameless plug


### PR DESCRIPTION
`dnode-php-sync-client` is [not maintained anymore](https://github.com/erasys/dnode-php-sync-client/pull/2#issuecomment-301440919) by the original authors. I forked it and added my own improvements.