### PR TITLE
Fixed error handling bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ dnode.prototype.listen = function () {
         
         stream.on('error', function (err) {
             if (err && err.code === 'EPIPE') return; // eat EPIPEs
-            d.emit('error', err);
+            server.emit('error', err);
         });
         
         d.stream = stream;


### PR DESCRIPTION
Emit event was being called on the wrong variable.  This should now allow proper error catching on the server side.  Specifically it fixes issue #178